### PR TITLE
Fix wasm deploy

### DIFF
--- a/.github/workflows/cd_wasm_gh-pages.yml
+++ b/.github/workflows/cd_wasm_gh-pages.yml
@@ -1,4 +1,4 @@
-name: deploy android/quest apk to gh-pages
+name: deploy wasm to gh-pages
 on:
   workflow_run:
     branches: [main]
@@ -25,7 +25,7 @@ jobs:
       - name: Install wasm libcore/libstd
         run: rustup target install wasm32-unknown-unknown
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli
+        run: wasm-bindgen --version || cargo install wasm-bindgen-cli
       - name: Build wasm
         run: cargo build --release --target wasm32-unknown-unknown --bin demo && wasm-bindgen --out-dir ./web/ --target web ./target/wasm32-unknown-unknown/release/demo.wasm
 


### PR DESCRIPTION
If a binary is already installed, there's no need to install it again.

If we want to update, we can clear the cache