### PR TITLE
We need to actually flush the async File to ensure everything gets written.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,10 +1282,11 @@ dependencies = [
 [[package]]
 name = "bevy_web_asset"
 version = "0.7.1"
-source = "git+https://github.com/oli-obk/bevy_web_asset.git?branch=android#938fbe7d39a88cad6a7648d84174dc14bf6ae729"
+source = "git+https://github.com/oli-obk/bevy_web_asset.git?branch=android#dfe8f5b6e7bf1dbbde2c1a8a577f5a381c6a6e77"
 dependencies = [
  "bevy",
  "js-sys",
+ "pin-project",
  "surf",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/src/http_assets.rs
+++ b/src/http_assets.rs
@@ -76,7 +76,9 @@ impl AssetReader for HttpAssetReader {
                 // Write asset to cache, but ensure only one HttpAssetReader writes at any given point in time
                 if self.sync.write().unwrap().insert(cache_path.clone()) {
                     async_fs::create_dir_all(cache_path.parent().unwrap()).await?;
-                    File::create(&cache_path).await?.write_all(&bytes).await?;
+                    let mut file = File::create(&cache_path).await?;
+                    file.write_all(&bytes).await?;
+                    file.flush().await?;
                 }
             }
             Ok(Box::new(VecReader::new(bytes)) as Box<Reader<'static>>)


### PR DESCRIPTION
The `Drop` impl won't do it for us like the `Drop` impl of `std::fs::File` does

fixes #46