### PR TITLE
load uncompressed glb files from server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,7 +3446,6 @@ dependencies = [
  "bevy_screen_diagnostics",
  "bevy_web_asset",
  "directories",
- "flate2",
  "futures-core",
  "futures-io",
  "glam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ opt-level = 3
 [dependencies]
 bevy = { version = "0.12", features = ["jpeg"] }
 bevy_flycam = { git = "https://github.com/oli-obk/bevy_flycam", branch = "arbitrary_up" }
-flate2 = "1.0.28"
 futures-core = "0.3.29"
 futures-io = "0.3.29"
 glam = "0"


### PR DESCRIPTION
no idea why web can't keep loading .gz files, so let's just stop loading them now that .glb files are available