### PR TITLE
Cleanups and more helper types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,8 +1350,7 @@ dependencies = [
 [[package]]
 name = "big_space"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e188fd79effffde07875b26a2999f6fabbc0695ef25316948dd09d29b6abe74d"
+source = "git+https://github.com/oli-obk/big_space.git?branch=world_query#2d08b10c02a7b0b2cf50166dccb23bc22acb419b"
 dependencies = [
  "bevy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ globe-rs = "0.1.8"
 directories = "5.0.1"
 async-fs = "2.1.0"
 bevy_web_asset = { git = "https://github.com/oli-obk/bevy_web_asset.git", branch = "user-agent" }
-big_space = "0.4.0"
+big_space = { git = "https://github.com/oli-obk/big_space.git", branch = "world_query" }
 bevy_embedded_assets = "0.9.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/flycam.rs
+++ b/src/flycam.rs
@@ -129,7 +129,7 @@ fn update_camera_speed(
     fly_cam: Query<GalacticTransform, With<FlyCam>>,
     space: Res<FloatingOriginSettings>,
 ) {
-    let elevation = fly_cam.single().grid_position_double(&space).length() as f32;
+    let elevation = fly_cam.single().position_double(&space).length() as f32;
     let speed = (1. * (elevation - crate::geopos::EARTH_RADIUS - 300.0)).max(100.0);
     movement_settings.speed = speed;
 }

--- a/src/geopos.rs
+++ b/src/geopos.rs
@@ -68,6 +68,7 @@ impl GeoPos {
         DVec3::new(-cart.x(), -cart.y(), cart.z())
     }
 
+    /// Compute the galactic position on the planet's surface.
     pub fn to_cartesian(self, space: &FloatingOriginSettings) -> Position<'_> {
         let pos = self.to_cartesian_vec();
         let (cell, pos) = space.translation_to_grid(pos);

--- a/src/geopos.rs
+++ b/src/geopos.rs
@@ -1,6 +1,5 @@
-use crate::{player::Position, tilemap::TileCoord, GalacticTransformOwned};
+use crate::{player::PlanetaryPosition, tilemap::TileCoord};
 use bevy::prelude::*;
-use big_space::FloatingOriginSettings;
 use glam::DVec3;
 use globe_rs::{CartesianPoint, GeographicPoint};
 use std::f32::consts::PI;
@@ -56,25 +55,16 @@ impl GeoPos {
         TileCoord::new(Vec2 { x, y }, zoom)
     }
 
-    /// Prefer using `to_cartesian`, which returns a [`Position`] that has a lot more convenience
-    /// methods.
-    pub fn to_cartesian_vec(self) -> DVec3 {
+    /// Compute the galactic position on the planet's surface.
+    pub fn to_cartesian(self) -> PlanetaryPosition {
         let geo = GeographicPoint::new(
             (self.lon as f64).to_radians(),
             (self.lat as f64).to_radians(),
             EARTH_RADIUS as f64,
         );
         let cart = CartesianPoint::from_geographic(&geo);
-        DVec3::new(-cart.x(), -cart.y(), cart.z())
-    }
-
-    /// Compute the galactic position on the planet's surface.
-    pub fn to_cartesian(self, space: &FloatingOriginSettings) -> Position<'_> {
-        let pos = self.to_cartesian_vec();
-        let (cell, pos) = space.translation_to_grid(pos);
-        let transform = Transform::from_translation(pos);
-        let pos = GalacticTransformOwned { transform, cell };
-        Position { pos, space }
+        let pos = DVec3::new(-cart.x(), -cart.y(), cart.z());
+        PlanetaryPosition { pos }
     }
 
     pub fn from_cartesian(pos: DVec3) -> Self {
@@ -89,9 +79,9 @@ impl GeoPos {
     /// Tile width and height in meters
     pub fn tile_size(self, zoom: u8) -> Vec2 {
         let coord = self.to_tile_coordinates(zoom);
-        let pos = self.to_cartesian_vec();
-        let x = coord.right().to_geo_pos().to_cartesian_vec().distance(pos) as f32;
-        let y = coord.down().to_geo_pos().to_cartesian_vec().distance(pos) as f32;
+        let pos = self.to_cartesian();
+        let x = coord.right().to_geo_pos().to_cartesian().distance(*pos) as f32;
+        let y = coord.down().to_geo_pos().to_cartesian().distance(*pos) as f32;
         Vec2 { x, y }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ use big_space::{
     FloatingOriginPlugin, FloatingOriginSettings, GridCell,
 };
 use geopos::{GeoPos, EARTH_RADIUS};
-use glam::DVec3;
 use http_assets::HttpAssetReaderPlugin;
+use player::PlanetaryPosition;
 use tilemap::{TileIndex, TileMap, TILE_ZOOM};
 
 mod flycam;
@@ -45,7 +45,7 @@ type GalacticTransformItem<'a> = GridTransformItem<'a, GridPrecision>;
 
 #[derive(Resource)]
 struct Args {
-    starting_position: DVec3,
+    starting_position: PlanetaryPosition,
     height: f32,
     direction: f32,
     view: f32,
@@ -103,7 +103,7 @@ pub fn main() {
 
     let mut app = App::new();
     app.insert_resource(Args {
-        starting_position: pos.to_cartesian_vec(),
+        starting_position: pos.to_cartesian(),
         height,
         direction,
         view,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub fn main() {
 
     let mut app = App::new();
     app.insert_resource(Args {
-        starting_position: pos.to_cartesian(),
+        starting_position: pos.to_cartesian_vec(),
         height,
         direction,
         view,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
-    ecs::query::WorldQuery,
     pbr::NotShadowCaster,
     prelude::*,
 };
@@ -16,7 +15,12 @@ use bevy_screen_diagnostics::{
     Aggregate, ScreenDiagnostics, ScreenDiagnosticsPlugin, ScreenEntityDiagnosticsPlugin,
     ScreenFrameDiagnosticsPlugin,
 };
-use big_space::{FloatingOriginPlugin, FloatingOriginSettings, GridCell};
+use big_space::{
+    world_query::{
+        GridTransform, GridTransformItem, GridTransformOwned, GridTransformReadOnlyItem,
+    },
+    FloatingOriginPlugin, FloatingOriginSettings, GridCell,
+};
 use geopos::{GeoPos, EARTH_RADIUS};
 use glam::DVec3;
 use http_assets::HttpAssetReaderPlugin;
@@ -32,6 +36,12 @@ mod xr;
 
 type GridPrecision = i64;
 type GalacticGrid = GridCell<GridPrecision>;
+type GalacticTransform = GridTransform<GridPrecision>;
+#[allow(dead_code)]
+type GalacticTransformOwned = GridTransformOwned<GridPrecision>;
+type GalacticTransformReadOnlyItem<'a> = GridTransformReadOnlyItem<'a, GridPrecision>;
+#[allow(dead_code)]
+type GalacticTransformItem<'a> = GridTransformItem<'a, GridPrecision>;
 
 #[derive(Resource)]
 struct Args {
@@ -269,7 +279,7 @@ fn reposition_compass(
         let player = player.pos();
         let directions = player.directions();
         compass.transform.translation = player.transform.translation - directions.up * 5.;
-        *compass.grid = *player.grid;
+        *compass.cell = *player.cell;
         compass.transform.look_to(directions.north, directions.up)
     } else {
         let mesh = shape::Plane::default();
@@ -304,7 +314,7 @@ fn update_camera_orientations(
 ) {
     movement_settings.up = fly_cam
         .single()
-        .grid_position_double(&space)
+        .position_double(&space)
         .normalize()
         .as_vec3();
 }
@@ -321,7 +331,7 @@ fn pull_to_ground(
     let adjustment_rate = (time.delta_seconds() * 10.0).min(1.0);
 
     // Lower player onto sphere
-    let real_pos = root.grid_position_double(&space);
+    let real_pos = root.position_double(&space);
     let up = real_pos.normalize();
     let diff = up * EARTH_RADIUS as f64 - real_pos;
     root.transform.translation += diff.as_vec3() * adjustment_rate;
@@ -330,23 +340,4 @@ fn pull_to_ground(
     let angle_diff = Quat::from_rotation_arc(root.transform.up(), up.as_vec3());
     root.transform
         .rotate(Quat::IDENTITY.slerp(angle_diff, adjustment_rate));
-}
-
-#[derive(WorldQuery)]
-#[world_query(mutable)]
-pub struct GalacticTransform {
-    pub transform: &'static mut Transform,
-    pub grid: &'static mut GalacticGrid,
-}
-
-impl<'w> GalacticTransformItem<'w> {
-    pub fn grid_position_double(&self, space: &FloatingOriginSettings) -> DVec3 {
-        space.grid_position_double(&self.grid, &self.transform)
-    }
-}
-
-impl<'w> GalacticTransformReadOnlyItem<'w> {
-    pub fn grid_position_double(&self, space: &FloatingOriginSettings) -> DVec3 {
-        space.grid_position_double(self.grid, self.transform)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ mod xr;
 type GridPrecision = i64;
 type GalacticGrid = GridCell<GridPrecision>;
 type GalacticTransform = GridTransform<GridPrecision>;
-#[allow(dead_code)]
 type GalacticTransformOwned = GridTransformOwned<GridPrecision>;
+#[allow(dead_code)]
 type GalacticTransformReadOnlyItem<'a> = GridTransformReadOnlyItem<'a, GridPrecision>;
 #[allow(dead_code)]
 type GalacticTransformItem<'a> = GridTransformItem<'a, GridPrecision>;
@@ -279,7 +279,7 @@ fn reposition_compass(
         let player = player.pos();
         let directions = player.directions();
         compass.transform.translation = player.transform.translation - directions.up * 5.;
-        *compass.cell = *player.cell;
+        *compass.cell = player.cell;
         compass.transform.look_to(directions.north, directions.up)
     } else {
         let mesh = shape::Plane::default();

--- a/src/player.rs
+++ b/src/player.rs
@@ -41,7 +41,7 @@ impl<'a> std::ops::Deref for PlayerPosition<'a> {
 
 impl PlayerPosition<'_> {
     pub fn pos(&self) -> DVec3 {
-        self.pos.grid_position_double(self.space)
+        self.pos.position_double(self.space)
     }
     pub fn directions(&self) -> Directions {
         let up = self.pos().normalize().as_vec3();

--- a/src/player.rs
+++ b/src/player.rs
@@ -27,6 +27,42 @@ pub struct Player<'w, 's> {
     pub(crate) space: Res<'w, FloatingOriginSettings>,
 }
 
+/// A helper for working with positions relative to the planet center.
+#[derive(Clone, Copy)]
+pub struct PlanetaryPosition {
+    pub pos: DVec3,
+}
+
+impl Into<DVec3> for PlanetaryPosition {
+    fn into(self) -> DVec3 {
+        self.pos
+    }
+}
+
+impl std::ops::Deref for PlanetaryPosition {
+    type Target = DVec3;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pos
+    }
+}
+
+impl PlanetaryPosition {
+    pub fn to_galactic_position(self, space: &FloatingOriginSettings) -> Position<'_> {
+        let (cell, pos) = space.translation_to_grid(self.pos);
+        let transform = Transform::from_translation(pos);
+        let pos = GalacticTransformOwned { transform, cell };
+        Position { pos, space }
+    }
+
+    pub fn directions(self) -> Directions {
+        let up = self.pos.normalize().as_vec3();
+        let west = Vec3::Z.cross(up);
+        let north = up.cross(west);
+        Directions { up, north, west }
+    }
+}
+
 /// A helper for working with galactic positions.
 pub struct Position<'a> {
     pub pos: GalacticTransformOwned,

--- a/src/player.rs
+++ b/src/player.rs
@@ -33,9 +33,9 @@ pub struct PlanetaryPosition {
     pub pos: DVec3,
 }
 
-impl Into<DVec3> for PlanetaryPosition {
-    fn into(self) -> DVec3 {
-        self.pos
+impl From<PlanetaryPosition> for DVec3 {
+    fn from(value: PlanetaryPosition) -> Self {
+        value.pos
     }
 }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,5 +1,5 @@
 use crate::GalacticTransform;
-use crate::GalacticTransformReadOnlyItem;
+use crate::GalacticTransformOwned;
 
 use super::Compass;
 use super::OpenXRTrackingRoot;
@@ -26,20 +26,20 @@ pub struct Player<'w, 's> {
     pub(crate) space: Res<'w, FloatingOriginSettings>,
 }
 
-pub struct PlayerPosition<'a> {
-    pub pos: GalacticTransformReadOnlyItem<'a>,
+pub struct Position<'a> {
+    pub pos: GalacticTransformOwned,
     pub space: &'a FloatingOriginSettings,
 }
 
-impl<'a> std::ops::Deref for PlayerPosition<'a> {
-    type Target = GalacticTransformReadOnlyItem<'a>;
+impl<'a> std::ops::Deref for Position<'a> {
+    type Target = GalacticTransformOwned;
 
     fn deref(&self) -> &Self::Target {
         &self.pos
     }
 }
 
-impl PlayerPosition<'_> {
+impl Position<'_> {
     pub fn pos(&self) -> DVec3 {
         self.pos.position_double(self.space)
     }
@@ -58,13 +58,14 @@ pub struct Directions {
 }
 
 impl<'w, 's> Player<'w, 's> {
-    pub fn pos(&self) -> PlayerPosition<'_> {
+    pub fn pos(&self) -> Position<'_> {
         let pos = if let Ok(xr_pos) = self.xr_pos.get_single() {
             xr_pos
         } else {
             self.flycam_pos.single()
-        };
-        PlayerPosition {
+        }
+        .to_owned();
+        Position {
             pos,
             space: &self.space,
         }

--- a/src/player.rs
+++ b/src/player.rs
@@ -10,6 +10,7 @@ use big_space::FloatingOriginSettings;
 use glam::DVec3;
 
 #[derive(SystemParam)]
+/// A helper argument for bevy systems that obtains the main player's position.
 pub struct Player<'w, 's> {
     pub(crate) xr_pos: Query<
         'w,
@@ -26,6 +27,7 @@ pub struct Player<'w, 's> {
     pub(crate) space: Res<'w, FloatingOriginSettings>,
 }
 
+/// A helper for working with galactic positions.
 pub struct Position<'a> {
     pub pos: GalacticTransformOwned,
     pub space: &'a FloatingOriginSettings,
@@ -40,9 +42,13 @@ impl<'a> std::ops::Deref for Position<'a> {
 }
 
 impl Position<'_> {
+    /// Compute the cartesian coordinates by combining the grid cell and the position from within
+    /// the grid.
     pub fn pos(&self) -> DVec3 {
         self.pos.position_double(self.space)
     }
+
+    /// Calculates cardinal directions at any cartesian position.
     pub fn directions(&self) -> Directions {
         let up = self.pos().normalize().as_vec3();
         let west = Vec3::Z.cross(up);
@@ -51,6 +57,7 @@ impl Position<'_> {
     }
 }
 
+/// A coordinate system where "forward" is north, "right" is west and "up" is away from the planet.
 pub struct Directions {
     pub up: Vec3,
     pub north: Vec3,
@@ -58,6 +65,7 @@ pub struct Directions {
 }
 
 impl<'w, 's> Player<'w, 's> {
+    /// Computes the galactic position of the main player (prefers XR player).
     pub fn pos(&self) -> Position<'_> {
         let pos = if let Ok(xr_pos) = self.xr_pos.get_single() {
             xr_pos

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -178,15 +178,10 @@ fn flat_tile(
 
     // Four corners of the tile in cartesian coordinates relative to the
     // planet's center.
-    let a = coord.to_geo_pos().to_cartesian_vec();
-    let b = pos.right().as_coord().to_geo_pos().to_cartesian_vec();
-    let c = pos
-        .down()
-        .right()
-        .as_coord()
-        .to_geo_pos()
-        .to_cartesian_vec();
-    let d = pos.down().as_coord().to_geo_pos().to_cartesian_vec();
+    let a = coord.to_geo_pos().to_cartesian();
+    let b = pos.right().as_coord().to_geo_pos().to_cartesian();
+    let c = pos.down().right().as_coord().to_geo_pos().to_cartesian();
+    let d = pos.down().as_coord().to_geo_pos().to_cartesian();
 
     // Normals on a sphere are just the position on the sphere normalized.
     let normals = vec![
@@ -197,9 +192,9 @@ fn flat_tile(
     ];
 
     // `a` is our anchor point, all others are relative
-    let b = b - a;
-    let c = c - a;
-    let d = d - a;
+    let b = *b - *a;
+    let c = *c - *a;
+    let d = *d - *a;
 
     let (grid, a) = space.translation_to_grid(a);
     let b = a + b.as_vec3();

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -7,7 +7,7 @@ use bevy::{
 };
 use big_space::FloatingOriginSettings;
 
-use crate::GalacticGrid;
+use crate::{GalacticGrid, GalacticTransformOwned};
 
 mod coord;
 mod index;
@@ -138,9 +138,9 @@ impl TileMap {
             LoadState::NotLoaded | LoadState::Loading => unreachable!(),
             LoadState::Loaded => {
                 entity.remove::<PbrBundle>();
-                let (grid, transform) = pos.to_cartesian(&space);
+                let GalacticTransformOwned { transform, cell } = pos.to_cartesian(&space);
                 let scene = scenes.get(scene).unwrap().scenes[0].clone();
-                entity.insert(grid);
+                entity.insert(cell);
                 entity.insert(SceneBundle {
                     scene, // "models/17430_11371.glb#Scene0"
                     transform,
@@ -178,10 +178,15 @@ fn flat_tile(
 
     // Four corners of the tile in cartesian coordinates relative to the
     // planet's center.
-    let a = coord.to_geo_pos().to_cartesian();
-    let b = pos.right().as_coord().to_geo_pos().to_cartesian();
-    let c = pos.down().right().as_coord().to_geo_pos().to_cartesian();
-    let d = pos.down().as_coord().to_geo_pos().to_cartesian();
+    let a = coord.to_geo_pos().to_cartesian_vec();
+    let b = pos.right().as_coord().to_geo_pos().to_cartesian_vec();
+    let c = pos
+        .down()
+        .right()
+        .as_coord()
+        .to_geo_pos()
+        .to_cartesian_vec();
+    let d = pos.down().as_coord().to_geo_pos().to_cartesian_vec();
 
     // Normals on a sphere are just the position on the sphere normalized.
     let normals = vec![

--- a/src/tilemap/coord.rs
+++ b/src/tilemap/coord.rs
@@ -48,6 +48,7 @@ impl TileCoord {
         }
     }
 
+    #[allow(dead_code)]
     pub fn up(self) -> Self {
         Self {
             pos: self.pos - Vec2::Y,

--- a/src/tilemap/index.rs
+++ b/src/tilemap/index.rs
@@ -66,9 +66,9 @@ impl TileIndex {
 
     pub fn to_cartesian(self, space: &FloatingOriginSettings) -> GalacticTransformOwned {
         let coord = self.as_coord().center();
-        let pos = coord.to_geo_pos().to_cartesian(space);
+        let pos = coord.to_geo_pos().to_cartesian();
         let Directions { up, north, west: _ } = pos.directions();
-        let mut pos = pos.pos;
+        let mut pos = pos.to_galactic_position(space).pos;
         pos.transform.look_to(north, up);
         pos
     }

--- a/src/tilemap/index.rs
+++ b/src/tilemap/index.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use super::coord::TileCoord;
-use crate::GalacticGrid;
+use crate::{player::Directions, GalacticTransformOwned};
 use bevy::prelude::*;
 use big_space::FloatingOriginSettings;
 
@@ -64,24 +64,13 @@ impl TileIndex {
         }
     }
 
-    pub fn to_cartesian(self, space: &FloatingOriginSettings) -> (GalacticGrid, Transform) {
+    pub fn to_cartesian(self, space: &FloatingOriginSettings) -> GalacticTransformOwned {
         let coord = self.as_coord().center();
-        let pos = coord.to_geo_pos().to_cartesian();
-        let up = pos.normalize().as_vec3();
-        let next = coord.up().to_geo_pos().to_cartesian();
-        let (grid, pos) = space.translation_to_grid(pos);
-        let (grid_next, next) = space.translation_to_grid(next);
-        let diff = grid_next - grid;
-        let diff = Vec3 {
-            x: diff.x as f32 * space.grid_edge_length(),
-            y: diff.y as f32 * space.grid_edge_length(),
-            z: diff.z as f32 * space.grid_edge_length(),
-        };
-        let next = next + diff;
-        (
-            grid,
-            Transform::from_translation(pos).looking_to(next - pos, up),
-        )
+        let pos = coord.to_geo_pos().to_cartesian(space);
+        let Directions { up, north, west: _ } = pos.directions();
+        let mut pos = pos.pos;
+        pos.transform.look_to(north, up);
+        pos
     }
 
     pub fn zoom(&self) -> u8 {


### PR DESCRIPTION
You can now use `GeoPos { lat, lon }.to_cartesian()` to obtain a `PlanetaryPosition`, which has a convenience method `directions` that gives you `up`, `north` and `west` vectors.

Do you need something else for #51 ?